### PR TITLE
冗長なpublicを削除

### DIFF
--- a/Conv/Algorithm/Differenciable.swift
+++ b/Conv/Algorithm/Differenciable.swift
@@ -16,7 +16,7 @@ public protocol Differenciable {
 }
 
 public extension Differenciable {
-    public func shouldUpdate(to compare: Differenciable) -> Bool {
+    func shouldUpdate(to compare: Differenciable) -> Bool {
         return differenceIdentifier != compare.differenceIdentifier
     }
 }

--- a/Conv/Conv/TaggedExtension.swift
+++ b/Conv/Conv/TaggedExtension.swift
@@ -22,11 +22,11 @@ public protocol ConvTaggedExtensionCompatible {
 }
 
 public extension ConvTaggedExtensionCompatible {
-    public static var conv: ConvTaggedExtension<Self>.Type {
+    static var conv: ConvTaggedExtension<Self>.Type {
         return ConvTaggedExtension<Self>.self
     }
     
-    public var conv: ConvTaggedExtension<Self> {
+    var conv: ConvTaggedExtension<Self> {
         return ConvTaggedExtension(self)
     }
 }


### PR DESCRIPTION
Xcode10.2とSwift5以降においてはPublic識別子内でPublic識別子を使うことは
冗長とされているようです。